### PR TITLE
Fix User email uniqueness field

### DIFF
--- a/src/main/java/com/uade/tpo/demo/entity/User.java
+++ b/src/main/java/com/uade/tpo/demo/entity/User.java
@@ -31,6 +31,7 @@ public class User implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String email;
 
     private String password;
@@ -38,10 +39,9 @@ public class User implements UserDetails {
     private LocalDate fechaNacimiento;
 
     private boolean membresiaActiva;
-    
+
     private String firstName;
 
-    @Column(nullable = false, unique = true)
     private String lastName;
 
     @OneToMany(mappedBy = "user")

--- a/src/test/java/com/uade/tpo/demo/UserEntityTest.java
+++ b/src/test/java/com/uade/tpo/demo/UserEntityTest.java
@@ -1,0 +1,31 @@
+package com.uade.tpo.demo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import com.uade.tpo.demo.entity.User;
+
+import jakarta.persistence.Column;
+
+class UserEntityTest {
+
+    @Test
+    void emailHasUniqueConstraint() throws Exception {
+        Field emailField = User.class.getDeclaredField("email");
+        Column column = emailField.getAnnotation(Column.class);
+        assertNotNull(column, "email field should have @Column annotation");
+        assertTrue(column.unique(), "email field should be marked unique");
+    }
+
+    @Test
+    void lastNameIsNotUnique() throws Exception {
+        Field lastNameField = User.class.getDeclaredField("lastName");
+        Column column = lastNameField.getAnnotation(Column.class);
+        if (column != null) {
+            assertFalse(column.unique(), "lastName field should not be unique");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure user email field has unique constraint
- add regression test for email and last name annotations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6848dfcc2cec8321aaebe6cabca94524